### PR TITLE
Added support for opening links in a new tab and better handling of content-disposition

### DIFF
--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -51,8 +51,6 @@ function eventClick(element, binding, pluginOptions) {
     downloadingText: "Downloading",
     downloadingHtml: "",
     dotsAnimation: true,
-
-    downloadMode: defaultDownloadMode
   }
 
   // try to get the values
@@ -212,7 +210,12 @@ function eventClick(element, binding, pluginOptions) {
       let fileName = href.substring(href.lastIndexOf("/") + 1)
       if (contentDisposition) {
         const fileNameMatch = contentDisposition.match(/filename="?(.+)"?/)
-        if (fileNameMatch != null && fileNameMatch.length === 2) fileName = fileNameMatch[1]
+        if (fileNameMatch != null && fileNameMatch.length === 2) {
+          fileName = fileNameMatch[1]
+          // content disposition filename is usually url encoded
+          fileName = fileName.replace(/\+/g, '%20')
+          fileName = decodeURIComponent(fileName);
+        }
       }
       if (element.hasAttribute("target")) {
         link.setAttribute("target", element.target)

--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -37,6 +37,8 @@ function eventClick(element, binding, pluginOptions) {
   // prevent default click action (click on a link)
   event && event.preventDefault()
 
+  const defaultDownloadMode = "download"
+
   // store the original href locally
   const href = element.href
 
@@ -51,6 +53,8 @@ function eventClick(element, binding, pluginOptions) {
     downloadingText: "Downloading",
     downloadingHtml: "",
     dotsAnimation: true,
+
+    downloadMode: defaultDownloadMode
   }
 
   // try to get the values
@@ -67,6 +71,21 @@ function eventClick(element, binding, pluginOptions) {
     throw Error(
       "v-auth-href: You must provide the Token via options on instanciate or v-auth-href values",
     )
+  }
+  
+  // downloadMode:
+  if (
+    typeof binding.value === "object" &&
+    binding.value.downloadMode &&
+    binding.value.downloadMode !== ""
+  ) {
+    options.downloadMode = binding.value.downloadMode
+  } else if (
+    typeof pluginOptions === "object" &&
+    pluginOptions.downloadMode &&
+    pluginOptions.downloadMode !== ""
+  ) {
+    options.downloadMode = pluginOptions.downloadMode
   }
 
   // Header: auth key (only via options)
@@ -209,10 +228,14 @@ function eventClick(element, binding, pluginOptions) {
       )
       let fileName = href.substring(href.lastIndexOf("/") + 1)
       if (contentDisposition) {
-        const fileNameMatch = contentDisposition.match(/filename="(.+)"/)
+        const fileNameMatch = contentDisposition.match(/filename="?(.+)"?/)
         if (fileNameMatch != null && fileNameMatch.length === 2) fileName = fileNameMatch[1]
       }
-      link.setAttribute("download", fileName)
+      if (options.downloadMode === defaultDownloadMode) {
+        link.setAttribute("download", fileName)        
+      } else {
+        link.setAttribute("target", options.downloadMode)
+      }
       document.body.appendChild(link)
       link.click()
       link.remove()

--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -51,6 +51,7 @@ function eventClick(element, binding, pluginOptions) {
     downloadingText: "Downloading",
     downloadingHtml: "",
     dotsAnimation: true,
+    overrideInnerHtml: true
   }
 
   // try to get the values
@@ -136,9 +137,9 @@ function eventClick(element, binding, pluginOptions) {
     }
 
     // dotsAnimation
-    if (typeof binding.value === "object" && binding.value.dotsAnimation) {
+    if (typeof binding.value === "object" && binding.value.dotsAnimation !== undefined) {
       options.dotsAnimation = Boolean(binding.value.dotsAnimation)
-    } else if (typeof pluginOptions === "object" && pluginOptions.dotsAnimation) {
+    } else if (typeof pluginOptions === "object" && pluginOptions.dotsAnimation !== undefined) {
       options.dotsAnimation = Boolean(pluginOptions.dotsAnimation)
     }
   } else if (options.textMode === "html") {
@@ -157,6 +158,13 @@ function eventClick(element, binding, pluginOptions) {
       options.downloadingHtml = pluginOptions.downloadingHtml
     }
   }
+  // overrideInnerHtml
+  if (typeof binding.value === "object" && binding.value.overrideInnerHtml !== undefined) {
+    options.overrideInnerHtml = Boolean(binding.value.overrideInnerHtml)
+  } else if (typeof pluginOptions === "object" && pluginOptions.overrideInnerHtml !== undefined) {
+    options.overrideInnerHtml = Boolean(pluginOptions.overrideInnerHtml)
+  }
+  
 
   // check if the attribete data-downloading is present. If it isn't, add it. If it's present, the link was already clicked so cancel the operation
   const isDownloading = element.getAttribute("data-downloading")
@@ -166,17 +174,19 @@ function eventClick(element, binding, pluginOptions) {
     return false
   }
 
-  // Save the original HTML node content and put the fancy message
-  files[href] = element.innerHTML
-  element.innerHTML =
-    options.textMode === "text" ? options.downloadingText : options.downloadingHtml
+  if (options.overrideInnerHtml) {
+    // Save the original HTML node content and put the fancy message
+    files[href] = element.innerHTML
+    element.innerHTML =
+      options.textMode === "text" ? options.downloadingText : options.downloadingHtml
+  }
 
   // Remove the original href to prevent click it more than once and also remove the anchor styles
   element.removeAttribute("href")
 
   // Sets the dots animation
   let interval
-  if (options.textMode === "text" && options.dotsAnimation === true) {
+  if (options.textMode === "text" && options.dotsAnimation === true && options.overrideInnerHtml === true) {
     interval = setInterval(() => {
       element.innerHTML += "."
       if (element.innerHTML.length === options.downloadingText.length + 3) {
@@ -232,10 +242,12 @@ function eventClick(element, binding, pluginOptions) {
     })
     .finally(() => {
       // Restore the link back to it's original state
-      if (options.textMode === "text" && options.dotsAnimation === true) {
-        clearInterval(interval)
+      if (options.overrideInnerHtml === true) {
+        if (options.textMode === "text" && options.dotsAnimation === true) {
+          clearInterval(interval)
+        }
+        element.innerHTML = files[href]
       }
-      element.innerHTML = files[href]
       element.setAttribute("href", href)
       element.removeAttribute("data-downloading")
     })

--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -37,8 +37,6 @@ function eventClick(element, binding, pluginOptions) {
   // prevent default click action (click on a link)
   event && event.preventDefault()
 
-  const defaultDownloadMode = "download"
-
   // store the original href locally
   const href = element.href
 
@@ -71,21 +69,6 @@ function eventClick(element, binding, pluginOptions) {
     throw Error(
       "v-auth-href: You must provide the Token via options on instanciate or v-auth-href values",
     )
-  }
-  
-  // downloadMode:
-  if (
-    typeof binding.value === "object" &&
-    binding.value.downloadMode &&
-    binding.value.downloadMode !== ""
-  ) {
-    options.downloadMode = binding.value.downloadMode
-  } else if (
-    typeof pluginOptions === "object" &&
-    pluginOptions.downloadMode &&
-    pluginOptions.downloadMode !== ""
-  ) {
-    options.downloadMode = pluginOptions.downloadMode
   }
 
   // Header: auth key (only via options)
@@ -231,10 +214,10 @@ function eventClick(element, binding, pluginOptions) {
         const fileNameMatch = contentDisposition.match(/filename="?(.+)"?/)
         if (fileNameMatch != null && fileNameMatch.length === 2) fileName = fileNameMatch[1]
       }
-      if (options.downloadMode === defaultDownloadMode) {
-        link.setAttribute("download", fileName)        
+      if (element.hasAttribute("target")) {
+        link.setAttribute("target", element.target)
       } else {
-        link.setAttribute("target", options.downloadMode)
+        link.setAttribute("download", fileName)
       }
       document.body.appendChild(link)
       link.click()


### PR DESCRIPTION
For my project, we are using asp.net core as backend and it generates something like this for the content-disposition:
"inline; filename=my+report-23.02.2021.pdf"

there are no quotes after filename like the original regex requires. I've altered the regex so that it also supports my case.

Additionally, since we are dealing with PDFs, we want to be able to open them and display them directly in the browser, as if we were doing target="_blank". This was not supported but I've added support for it by reading the original element's target attribute. Another way would have been to add an option for it but I think this is better and more expected.

Lastly, filename is usually url encoded in content-disposition, therefore I am decoding it, if it wasn't encoded, nothing should change compared to before my code.