### PR TITLE
fix: discard last quote " in regex while extracting fileName from Content-Disposition header

### DIFF
--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -240,7 +240,7 @@ function eventClick(element, binding, pluginOptions) {
       )
       let fileName = href.substring(href.lastIndexOf("/") + 1)
       if (contentDisposition) {
-        const fileNameMatch = contentDisposition.match(/filename="?(.+)"?/)
+        const fileNameMatch = contentDisposition.match(/filename="?(.+?)"?$/)
         if (fileNameMatch != null && fileNameMatch.length === 2) {
           fileName = fileNameMatch[1]
           // content disposition filename is usually url encoded


### PR DESCRIPTION
When Content-Disposition=attachment; filename="myFile.pdf"
the regex will extract fileName=myFile.pdf"
With this regex the last quote is correctly discarded.

See: [](https://stackoverflow.com/questions/68303920/how-can-i-extract-a-string-between-optional-quotes)