### PR TITLE
added finish callback

### DIFF
--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -55,7 +55,9 @@ function eventClick(element, binding, pluginOptions) {
     removeDelay: -1,
     errorHandler: e => {
       throw e
-    }
+    },
+    
+    onFinishCallback: () => {}
   }
 
   // try to get the values
@@ -182,6 +184,13 @@ function eventClick(element, binding, pluginOptions) {
   } else if (typeof pluginOptions === "object" && pluginOptions.errorHandler !== undefined) {
     options.errorHandler = pluginOptions.errorHandler
   }
+  
+  // onFinishCallback
+  if (typeof binding.value === "object" && binding.value.onFinishCallback !== undefined) {
+    options.onFinishCallback = binding.value.onFinishCallback
+  } else if (typeof pluginOptions === "object" && pluginOptions.onFinishCallback !== undefined) {
+    options.onFinishCallback = pluginOptions.onFinishCallback
+  }  
 
   // check if the attribete data-downloading is present. If it isn't, add it. If it's present, the link was already clicked so cancel the operation
   const isDownloading = element.getAttribute("data-downloading")
@@ -282,6 +291,10 @@ function eventClick(element, binding, pluginOptions) {
       }
       element.setAttribute("href", href)
       element.removeAttribute("data-downloading")
+      
+      if (options.onFinishCallback) {
+        options.onFinishCallback()
+      }      
     })
 }
 


### PR DESCRIPTION
Hello,

I've added this new optional callback which is similar in usefulness to the errorHandler I previously added. I need this because I have a link which contains some text from vue which is reactive, and with the current working of vue-auth-href, is that when it has finished running the axios call, it replaces the text back to what it was before, but it's no longer reactive. Having this callback allows me for instance to change the key of the element to force vue to refresh it and then the content is reactive again.

Please let me know when you can create a new release with this change ;)