### PR TITLE
Update vue-auth-download.js

### DIFF
--- a/src/vue-auth-download.js
+++ b/src/vue-auth-download.js
@@ -56,7 +56,7 @@ function eventClick(element, binding, pluginOptions) {
     errorHandler: e => {
       throw e
     },
-
+    beforeDownloadCallback: () => {},
     onFinishCallback: () => {}
   }
 
@@ -227,6 +227,10 @@ function eventClick(element, binding, pluginOptions) {
 
   const authHeader = {}
   authHeader[options.headerAuthKey] = `${options.headerAuthValuePrefix}${options.token}`
+
+  if (options.beforeDownloadCallback) {
+    options.beforeDownloadCallback()
+  }
 
   axios({
     method: "GET",


### PR DESCRIPTION
Add a callback before a download starts. We urgently need this inside the package to be able to set a onbeforeunload listener to prevent our customers to kill an ongoing download by reloading the page. Please verify the changes and publish them as v1.5.1.